### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub Certifications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This PR adds the missing "GitHub Skills" activity to the school activities signup system, as requested in issue #6. The activity is now available for student registration with details about learning coding and collaboration skills through GitHub Certifications.

**Changes:**
- Added "GitHub Skills" entry to the activities dictionary in `src/app.py`
- Includes description, schedule (Wednesdays 3:30-5:00 PM), max participants (20), and empty participant list

Closes #6